### PR TITLE
change the related_name of MeasureGroup

### DIFF
--- a/withingsapp/models.py
+++ b/withingsapp/models.py
@@ -129,7 +129,9 @@ class Measure(models.Model):
     )
 
     group = models.ForeignKey(
-        MeasureGroup, help_text="The measurement's group")
+        MeasureGroup,
+        related_name='measures',
+        help_text="The measurement's group")
     value = models.IntegerField(
         help_text=(
             'Value for the measure in S.I units (kilogram, meters, etc.). '

--- a/withingsapp/tests/test_models.py
+++ b/withingsapp/tests/test_models.py
@@ -65,11 +65,11 @@ class TestWithingsModels(WithingsTestBase):
         self.assertEqual(MeasureGroup.objects.count(), 3)
         self.assertEqual(Measure.objects.count(), 5)
         self.assertEqual(
-            MeasureGroup.objects.get(grpid=2908).measure_set.count(), 1)
+            MeasureGroup.objects.get(grpid=2908).measures.count(), 1)
         self.assertEqual(
-            MeasureGroup.objects.get(grpid=2909).measure_set.count(), 1)
+            MeasureGroup.objects.get(grpid=2909).measures.count(), 1)
         self.assertEqual(
-            MeasureGroup.objects.get(grpid=2910).measure_set.count(), 3)
+            MeasureGroup.objects.get(grpid=2910).measures.count(), 3)
         # create_from_measures should silently ignore duplicates
         try:
             MeasureGroup.create_from_measures(self.user, measures)


### PR DESCRIPTION
@orcasgit/orcas-developers :eye: This changes the `related_name` of `MeasureGroup` so that django-tastypie-swagger works with this model.